### PR TITLE
Pydantic version workaround

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     httpx >= 0.23.3
     dateparser >= 1.1.1
     gpxpy >= 1.5.0
-    pydantic ~= 1.8.2
+    pydantic >= 1.8.2,<2.0
     pytz >= 2021.1
     importlib-metadata; python_version<"3.8"
 


### PR DESCRIPTION
Closed range for `pydantic` (any version below v2.0) [Pydantic v2.0 not supported at the moment]