### PR TITLE
Support pydantic v2

### DIFF
--- a/erclient/schemas.py
+++ b/erclient/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class ERLocation(BaseModel):

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     httpx >= 0.23.3
     dateparser >= 1.1.1
     gpxpy >= 1.5.0
-    pydantic >= 1.8.2,<2.0
+    pydantic >= 1.8.2
     pytz >= 2021.1
     importlib-metadata; python_version<"3.8"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     httpx >= 0.23.3
     dateparser >= 1.1.1
     gpxpy >= 1.5.0
-    pydantic >= 1.8.2
+    pydantic >= 1.10.17
     pytz >= 2021.1
     importlib-metadata; python_version<"3.8"
 


### PR DESCRIPTION
Hopefully this isn't too controversial, it allows `er-client` to work with a pydantic v2 install, as the upper bounds pin of `pydantic<2` creates a dependency conflict within [`ecoscope-workflows`](ecoscope-workflows)