### PR TITLE
Add add_subjects_to_subjectgroup to AsyncERClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Disclaimer: The async client current capabilities are limited to:
 * Getting Feature groups
 * Getting Sources
 * Getting Source Assignments (aka SubjectSource resources)
+* Deleting Subjects
+* Deleting Sources
 ```
 from erclient import AsyncERClient
 

--- a/erclient/client.py
+++ b/erclient/client.py
@@ -1364,6 +1364,17 @@ class AsyncERClient(object):
         self.logger.debug(f'Patching subject {subject_id}: {data}')
         return await self._patch(f'subject/{subject_id}', payload=data)
 
+    async def add_subjects_to_subjectgroup(self, group_id, subjects):
+        """
+        Add subjects to a subject group.
+
+        :param group_id: The subject group UUID
+        :param subjects: List of subject dicts with 'id' key (e.g., [{"id": "subject-uuid"}])
+        :return: Response data
+        """
+        self.logger.debug(f'Adding subjects to subjectgroup {group_id}: {subjects}')
+        return await self._post(f'subjectgroup/{group_id}/subjects/', payload=subjects)
+
     def _clean_observation(self, observation):
         if hasattr(observation['recorded_at'], 'isoformat'):
             observation['recorded_at'] = observation['recorded_at'].isoformat()

--- a/erclient/client.py
+++ b/erclient/client.py
@@ -87,7 +87,8 @@ class ERClient(object):
         self.client_id = kwargs.get('client_id')
         self.provider_key = kwargs.get('provider_key')
 
-        self.token_url = kwargs.get('token_url') or f"{self.service_root.rstrip('/')}/oauth2/token"
+        self.token_url = kwargs.get(
+            'token_url') or f"{self.service_root.rstrip('/')}/oauth2/token"
         self.username = kwargs.get('username')
         self.password = kwargs.get('password')
         self.realtime_url = kwargs.get('realtime_url')
@@ -1032,6 +1033,53 @@ class ERClient(object):
 
         return self._get('subjectgroups', params=p)
 
+    def add_subjects_to_subjectgroup(self, group_id, subjects):
+        """
+        Add subjects to a subject group.
+
+        :param group_id: The subject group UUID
+        :param subjects: List of subject dicts with 'id' key (e.g., [{"id": "subject-uuid"}])
+        :return: Response data
+        """
+        self.logger.debug(
+            f'Adding subjects to subjectgroup {group_id}: {subjects}')
+        return self._post(f'subjectgroup/{group_id}/subjects/', payload=subjects)
+
+    def remove_subjects_from_subjectgroup(self, group_id, subjects):
+        """
+        Remove subjects from a subject group.
+
+        :param group_id: The subject group UUID
+        :param subjects: List of subject dicts with 'id' key (e.g., [{"id": "subject-uuid"}])
+        :return: True on success
+        """
+        self.logger.debug(
+            f'Removing subjects from subjectgroup {group_id}: {subjects}')
+        headers = {'User-Agent': self.user_agent,
+                   'Content-Type': 'application/json'}
+        headers.update(self.auth_headers())
+        url = self._er_url(f'subjectgroup/{group_id}/subjects/')
+        if self._http_session:
+            response = self._http_session.delete(
+                url, headers=headers, json=subjects)
+        else:
+            response = requests.delete(url, headers=headers, json=subjects)
+        if response.ok:
+            return True
+        if response.status_code == 404:
+            self.logger.error(
+                f"404 when calling subjectgroup/{group_id}/subjects/")
+            raise ERClientNotFound()
+        if response.status_code == 403:
+            try:
+                _ = json.loads(response.text)
+                reason = _['status']['detail']
+            except Exception:
+                reason = 'unknown reason'
+            raise ERClientPermissionDenied(reason)
+        raise ERClientException(
+            f'Failed to delete: {response.status_code} {response.text}')
+
     def get_sources(self, page_size=100):
         """Return all sources"""
         params = dict(page_size=page_size)
@@ -1108,7 +1156,8 @@ class AsyncERClient(object):
         self.client_id = kwargs.get('client_id')
         self.provider_key = kwargs.get('provider_key')
 
-        self.token_url = kwargs.get('token_url') or f"{self.service_root.rstrip('/')}/oauth2/token"
+        self.token_url = kwargs.get(
+            'token_url') or f"{self.service_root.rstrip('/')}/oauth2/token"
         self.username = kwargs.get('username')
         self.password = kwargs.get('password')
         self.realtime_url = kwargs.get('realtime_url')
@@ -1372,8 +1421,25 @@ class AsyncERClient(object):
         :param subjects: List of subject dicts with 'id' key (e.g., [{"id": "subject-uuid"}])
         :return: Response data
         """
-        self.logger.debug(f'Adding subjects to subjectgroup {group_id}: {subjects}')
+        self.logger.debug(
+            f'Adding subjects to subjectgroup {group_id}: {subjects}')
         return await self._post(f'subjectgroup/{group_id}/subjects/', payload=subjects)
+
+    async def remove_subjects_from_subjectgroup(self, group_id, subjects):
+        """
+        Remove subjects from a subject group.
+
+        :param group_id: The subject group UUID
+        :param subjects: List of subject dicts with 'id' key (e.g., [{"id": "subject-uuid"}])
+        :return: True on success
+        """
+        self.logger.debug(
+            f'Removing subjects from subjectgroup {group_id}: {subjects}')
+        return await self._call(
+            f'subjectgroup/{group_id}/subjects/',
+            payload=subjects,
+            method="DELETE"
+        )
 
     def _clean_observation(self, observation):
         if hasattr(observation['recorded_at'], 'isoformat'):
@@ -1753,7 +1819,8 @@ class AsyncERClient(object):
                     request_url,
                     # payload is automatically encoded as json data
                     json=payload if method in [
-                        "POST", "PUT", "PATCH"] else None,
+                        "POST", "PUT", "PATCH"] or (
+                        method == "DELETE" and payload is not None) else None,
                     params=params,
                     headers=headers
                 )
@@ -1776,7 +1843,9 @@ class AsyncERClient(object):
                     return True  # DELETE/empty success
 
                 json_response = response.json()
-                return json_response.get('data', json_response)
+                if isinstance(json_response, dict):
+                    return json_response.get('data', json_response)
+                return json_response
 
     def _get_batches(self, data, batch_size):
         for i in range(0, len(data), batch_size):

--- a/erclient/client.py
+++ b/erclient/client.py
@@ -1047,7 +1047,7 @@ class ERClient(object):
 
     def remove_subjects_from_subjectgroup(self, group_id, subjects):
         """
-        Remove subjects from a subject group.
+        Remove subjects from a subject group. _delete method is not used, because it does not support a body.
 
         :param group_id: The subject group UUID
         :param subjects: List of subject dicts with 'id' key (e.g., [{"id": "subject-uuid"}])
@@ -1744,38 +1744,6 @@ class AsyncERClient(object):
 
     async def _get(self, path, base_url=None, params=None):
         return await self._call(path=path, payload=None, method="GET", params=params, base_url=base_url)
-
-    async def _delete(self, path):
-        """Issue DELETE request. Returns True on success; raises ERClient* on error."""
-        try:
-            auth_headers = await self.auth_headers()
-        except httpx.HTTPStatusError as e:
-            self._handle_http_status_error(path, "DELETE", e)
-        headers = {'User-Agent': self.user_agent, **auth_headers}
-        if not path.startswith('http'):
-            path = self._er_url(path)
-        try:
-            response = await self._http_session.delete(path, headers=headers)
-        except httpx.RequestError as e:
-            reason = str(e)
-            self.logger.error('Request to ER failed', extra=dict(provider_key=self.provider_key,
-                                                                 url=path,
-                                                                 reason=reason))
-            raise ERClientException(f'Request to ER failed: {reason}')
-        if response.is_success:
-            return True
-        if response.status_code == 404:
-            self.logger.error("404 when calling %s", path)
-            raise ERClientNotFound()
-        if response.status_code == 403:
-            try:
-                reason = response.json().get('status', {}).get('detail', 'unknown reason')
-            except Exception:
-                reason = 'unknown reason'
-            raise ERClientPermissionDenied(reason)
-        raise ERClientException(
-            f'Failed to delete: {response.status_code} {response.text}'
-        )
 
     async def get_file(self, url):
         """

--- a/erclient/client.py
+++ b/erclient/client.py
@@ -1413,6 +1413,28 @@ class AsyncERClient(object):
         self.logger.debug(f'Patching subject {subject_id}: {data}')
         return await self._patch(f'subject/{subject_id}', payload=data)
 
+    async def delete_subject(self, subject_id):
+        """
+        Delete a subject from EarthRanger.
+
+        WARNING: Irreversible — deleted subjects lose all observation history.
+
+        :param subject_id: The subject UUID
+        """
+        self.logger.debug(f'Deleting subject {subject_id}')
+        return await self._delete(f'subject/{subject_id}/')
+
+    async def delete_source(self, source_id):
+        """
+        Delete a source from EarthRanger.
+
+        WARNING: Irreversible — deleted sources lose all linked observation history.
+
+        :param source_id: The source UUID
+        """
+        self.logger.debug(f'Deleting source {source_id}')
+        return await self._delete(f'source/{source_id}/')
+
     async def add_subjects_to_subjectgroup(self, group_id, subjects):
         """
         Add subjects to a subject group.

--- a/tests/async_client/test_add_subjects_to_subjectgroup.py
+++ b/tests/async_client/test_add_subjects_to_subjectgroup.py
@@ -1,0 +1,113 @@
+import httpx
+import pytest
+import respx
+
+from erclient import (ERClientBadCredentials, ERClientInternalError,
+                      ERClientNotFound, ERClientPermissionDenied)
+
+
+GROUP_ID = "ac1413b9-8177-4a81-85d6-a46fc95bdd70"
+SUBJECT_ID = "1fed139e-070d-464c-9652-e9420437b068"
+SUBJECTS_PAYLOAD = [{"id": SUBJECT_ID}]
+
+
+@pytest.fixture
+def subjectgroup_subjects_response():
+    return [{"id": SUBJECT_ID, "name": "MMVessel"}]
+
+
+@pytest.mark.asyncio
+async def test_add_subjects_to_subjectgroup_success(er_client, subjectgroup_subjects_response):
+    """Test successful subject assignment to a subject group."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(
+            httpx.codes.OK, json=subjectgroup_subjects_response
+        )
+
+        result = await er_client.add_subjects_to_subjectgroup(
+            group_id=GROUP_ID,
+            subjects=SUBJECTS_PAYLOAD,
+        )
+
+        assert result == subjectgroup_subjects_response
+        assert route.called
+        await er_client.close()
+
+
+@pytest.mark.asyncio
+async def test_add_subjects_to_subjectgroup_not_found(er_client):
+    """Test 404 raises ERClientNotFound."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(httpx.codes.NOT_FOUND, json={})
+
+        with pytest.raises(ERClientNotFound):
+            await er_client.add_subjects_to_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        assert route.called
+        await er_client.close()
+
+
+@pytest.mark.asyncio
+async def test_add_subjects_to_subjectgroup_bad_credentials(er_client):
+    """Test 401 raises ERClientBadCredentials."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(httpx.codes.UNAUTHORIZED, json={})
+
+        with pytest.raises(ERClientBadCredentials):
+            await er_client.add_subjects_to_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        assert route.called
+        await er_client.close()
+
+
+@pytest.mark.asyncio
+async def test_add_subjects_to_subjectgroup_permission_denied(er_client):
+    """Test 403 raises ERClientPermissionDenied."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(httpx.codes.FORBIDDEN, json={})
+
+        with pytest.raises(ERClientPermissionDenied):
+            await er_client.add_subjects_to_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        assert route.called
+        await er_client.close()
+
+
+@pytest.mark.asyncio
+async def test_add_subjects_to_subjectgroup_internal_error(er_client):
+    """Test 500 raises ERClientInternalError."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(httpx.codes.INTERNAL_SERVER_ERROR, json={})
+
+        with pytest.raises(ERClientInternalError):
+            await er_client.add_subjects_to_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        assert route.called
+        await er_client.close()

--- a/tests/async_client/test_add_subjects_to_subjectgroup.py
+++ b/tests/async_client/test_add_subjects_to_subjectgroup.py
@@ -1,10 +1,12 @@
+import json
+
 import httpx
 import pytest
+import pytest_asyncio
 import respx
 
 from erclient import (ERClientBadCredentials, ERClientInternalError,
                       ERClientNotFound, ERClientPermissionDenied)
-
 
 GROUP_ID = "ac1413b9-8177-4a81-85d6-a46fc95bdd70"
 SUBJECT_ID = "1fed139e-070d-464c-9652-e9420437b068"
@@ -14,6 +16,12 @@ SUBJECTS_PAYLOAD = [{"id": SUBJECT_ID}]
 @pytest.fixture
 def subjectgroup_subjects_response():
     return [{"id": SUBJECT_ID, "name": "MMVessel"}]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def close_client(er_client):
+    yield
+    await er_client.close()
 
 
 @pytest.mark.asyncio
@@ -34,7 +42,6 @@ async def test_add_subjects_to_subjectgroup_success(er_client, subjectgroup_subj
 
         assert result == subjectgroup_subjects_response
         assert route.called
-        await er_client.close()
 
 
 @pytest.mark.asyncio
@@ -53,7 +60,6 @@ async def test_add_subjects_to_subjectgroup_not_found(er_client):
             )
 
         assert route.called
-        await er_client.close()
 
 
 @pytest.mark.asyncio
@@ -72,7 +78,6 @@ async def test_add_subjects_to_subjectgroup_bad_credentials(er_client):
             )
 
         assert route.called
-        await er_client.close()
 
 
 @pytest.mark.asyncio
@@ -91,7 +96,6 @@ async def test_add_subjects_to_subjectgroup_permission_denied(er_client):
             )
 
         assert route.called
-        await er_client.close()
 
 
 @pytest.mark.asyncio
@@ -101,7 +105,8 @@ async def test_add_subjects_to_subjectgroup_internal_error(er_client):
             base_url=er_client._api_root("v1.0"), assert_all_called=False
     ) as respx_mock:
         route = respx_mock.post(f'subjectgroup/{GROUP_ID}/subjects/')
-        route.return_value = httpx.Response(httpx.codes.INTERNAL_SERVER_ERROR, json={})
+        route.return_value = httpx.Response(
+            httpx.codes.INTERNAL_SERVER_ERROR, json={})
 
         with pytest.raises(ERClientInternalError):
             await er_client.add_subjects_to_subjectgroup(
@@ -110,4 +115,77 @@ async def test_add_subjects_to_subjectgroup_internal_error(er_client):
             )
 
         assert route.called
-        await er_client.close()
+
+
+@pytest.mark.asyncio
+async def test_remove_subjects_from_subjectgroup_success(er_client):
+    """Test successful removal of subjects from a subject group."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.delete(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(httpx.codes.NO_CONTENT)
+
+        result = await er_client.remove_subjects_from_subjectgroup(
+            group_id=GROUP_ID,
+            subjects=SUBJECTS_PAYLOAD,
+        )
+
+        assert result is True
+        assert route.called
+        assert json.loads(route.calls.last.request.content) == SUBJECTS_PAYLOAD
+
+
+@pytest.mark.asyncio
+async def test_remove_subjects_from_subjectgroup_not_found(er_client):
+    """Test 404 raises ERClientNotFound."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.delete(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(httpx.codes.NOT_FOUND, json={})
+
+        with pytest.raises(ERClientNotFound):
+            await er_client.remove_subjects_from_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        assert route.called
+
+
+@pytest.mark.asyncio
+async def test_remove_subjects_from_subjectgroup_permission_denied(er_client):
+    """Test 403 raises ERClientPermissionDenied."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.delete(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(httpx.codes.FORBIDDEN, json={})
+
+        with pytest.raises(ERClientPermissionDenied):
+            await er_client.remove_subjects_from_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        assert route.called
+
+
+@pytest.mark.asyncio
+async def test_remove_subjects_from_subjectgroup_internal_error(er_client):
+    """Test 500 raises ERClientInternalError."""
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.delete(f'subjectgroup/{GROUP_ID}/subjects/')
+        route.return_value = httpx.Response(
+            httpx.codes.INTERNAL_SERVER_ERROR, json={})
+
+        with pytest.raises(ERClientInternalError):
+            await er_client.remove_subjects_from_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        assert route.called

--- a/tests/sync_client/test_add_subjects_to_subjectgroup.py
+++ b/tests/sync_client/test_add_subjects_to_subjectgroup.py
@@ -1,0 +1,169 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from erclient import (ERClientException, ERClientNotFound,
+                      ERClientPermissionDenied)
+from erclient.client import ERClient
+
+GROUP_ID = "ac1413b9-8177-4a81-85d6-a46fc95bdd70"
+SUBJECT_ID = "1fed139e-070d-464c-9652-e9420437b068"
+SUBJECTS_PAYLOAD = [{"id": SUBJECT_ID}]
+
+
+def _mock_response(status_code, json_data=None):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    if json_data is not None:
+        resp.json.return_value = json_data
+        resp.text = json.dumps(json_data)
+    else:
+        resp.json.return_value = {}
+        resp.text = ""
+    return resp
+
+
+def test_add_subjects_to_subjectgroup_success(er_server_info):
+    """Test successful subject assignment to a subject group."""
+    response_data = [{"id": SUBJECT_ID, "name": "MMVessel"}]
+    with patch("erclient.client.requests.Session") as mock_session:
+        mock_session_instance = MagicMock()
+        mock_session_instance.post.return_value = _mock_response(
+            200, response_data)
+        mock_session.return_value = mock_session_instance
+
+        client = ERClient(**er_server_info)
+        result = client.add_subjects_to_subjectgroup(
+            group_id=GROUP_ID,
+            subjects=SUBJECTS_PAYLOAD,
+        )
+
+        mock_session_instance.post.assert_called_once()
+        call_url = mock_session_instance.post.call_args[0][0]
+        assert f"subjectgroup/{GROUP_ID}/subjects/" in call_url
+        assert result == response_data
+
+
+def test_add_subjects_to_subjectgroup_not_found(er_server_info):
+    """Test 404 raises ERClientNotFound."""
+    with patch("erclient.client.requests.Session") as mock_session:
+        mock_session_instance = MagicMock()
+        mock_session_instance.post.return_value = _mock_response(404)
+        mock_session.return_value = mock_session_instance
+
+        client = ERClient(**er_server_info)
+        with pytest.raises(ERClientNotFound):
+            client.add_subjects_to_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        mock_session_instance.post.assert_called_once()
+
+
+def test_add_subjects_to_subjectgroup_permission_denied(er_server_info):
+    """Test 403 raises ERClientPermissionDenied."""
+    with patch("erclient.client.requests.Session") as mock_session:
+        mock_session_instance = MagicMock()
+        mock_session_instance.post.return_value = _mock_response(403)
+        mock_session.return_value = mock_session_instance
+
+        client = ERClient(**er_server_info)
+        with pytest.raises(ERClientPermissionDenied):
+            client.add_subjects_to_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        mock_session_instance.post.assert_called_once()
+
+
+def test_add_subjects_to_subjectgroup_server_error(er_server_info):
+    """Test 500 raises ERClientException."""
+    with patch("erclient.client.requests.Session") as mock_session:
+        mock_session_instance = MagicMock()
+        mock_session_instance.post.return_value = _mock_response(500)
+        mock_session.return_value = mock_session_instance
+
+        client = ERClient(**er_server_info)
+        with pytest.raises(ERClientException):
+            client.add_subjects_to_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        mock_session_instance.post.assert_called_once()
+
+
+def test_remove_subjects_from_subjectgroup_success(er_server_info):
+    """Test successful removal of subjects from a subject group."""
+    with patch("erclient.client.requests.Session") as mock_session:
+        mock_session_instance = MagicMock()
+        mock_session_instance.delete.return_value = _mock_response(200)
+        mock_session.return_value = mock_session_instance
+
+        client = ERClient(**er_server_info)
+        result = client.remove_subjects_from_subjectgroup(
+            group_id=GROUP_ID,
+            subjects=SUBJECTS_PAYLOAD,
+        )
+
+        mock_session_instance.delete.assert_called_once()
+        call_args = mock_session_instance.delete.call_args
+        assert f"subjectgroup/{GROUP_ID}/subjects/" in call_args[0][0]
+        assert call_args[1]["json"] == SUBJECTS_PAYLOAD
+        assert result is True
+
+
+def test_remove_subjects_from_subjectgroup_not_found(er_server_info):
+    """Test 404 raises ERClientNotFound."""
+    with patch("erclient.client.requests.Session") as mock_session:
+        mock_session_instance = MagicMock()
+        mock_session_instance.delete.return_value = _mock_response(404)
+        mock_session.return_value = mock_session_instance
+
+        client = ERClient(**er_server_info)
+        with pytest.raises(ERClientNotFound):
+            client.remove_subjects_from_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        mock_session_instance.delete.assert_called_once()
+
+
+def test_remove_subjects_from_subjectgroup_permission_denied(er_server_info):
+    """Test 403 raises ERClientPermissionDenied."""
+    with patch("erclient.client.requests.Session") as mock_session:
+        mock_session_instance = MagicMock()
+        mock_session_instance.delete.return_value = _mock_response(403)
+        mock_session.return_value = mock_session_instance
+
+        client = ERClient(**er_server_info)
+        with pytest.raises(ERClientPermissionDenied):
+            client.remove_subjects_from_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        mock_session_instance.delete.assert_called_once()
+
+
+def test_remove_subjects_from_subjectgroup_server_error(er_server_info):
+    """Test 500 raises ERClientException."""
+    with patch("erclient.client.requests.Session") as mock_session:
+        mock_session_instance = MagicMock()
+        mock_session_instance.delete.return_value = _mock_response(500)
+        mock_session.return_value = mock_session_instance
+
+        client = ERClient(**er_server_info)
+        with pytest.raises(ERClientException):
+            client.remove_subjects_from_subjectgroup(
+                group_id=GROUP_ID,
+                subjects=SUBJECTS_PAYLOAD,
+            )
+
+        mock_session_instance.delete.assert_called_once()


### PR DESCRIPTION
Adds three new methods to AsyncERClient:                                                                                                                   
                                                                                                          
add_subjects_to_subjectgroup posts to /subjectgroup/{id}/subjects/ to add a list of subjects to a subject group.                                           
   
delete_subject and delete_source send DELETE requests to /subject/{id}/ and /source/{id}/ respectively. Both are irreversible — deleted records lose all linked observation history in EarthRanger. 