### PR TITLE
Expose Retry-After header on ER client exceptions

### DIFF
--- a/erclient/client.py
+++ b/erclient/client.py
@@ -41,8 +41,11 @@ def parse_retry_after_header(value):
         pass
     try:
         retry_at = parsedate_to_datetime(value)
-        seconds = int((retry_at - datetime.now(timezone.utc)).total_seconds())
-        return seconds if seconds >= 0 else None
+        delta = (retry_at - datetime.now(timezone.utc)).total_seconds()
+        if delta < 0:
+            return None
+        # Round up so we never retry earlier than the server requested
+        return math.ceil(delta)
     except (TypeError, ValueError):
         return None
 

--- a/erclient/client.py
+++ b/erclient/client.py
@@ -7,6 +7,7 @@ import re
 import time
 import warnings
 from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 from http import HTTPStatus
 from typing import List
 from urllib.parse import urlparse, urlunparse
@@ -27,6 +28,23 @@ from .er_errors import (ERClientBadCredentials, ERClientBadRequest,
 from .version import __version__
 
 version_string = __version__
+
+
+def parse_retry_after_header(value):
+    """Parse a Retry-After header (delta-seconds or HTTP-date) into seconds, or None."""
+    if not value:
+        return None
+    try:
+        seconds = int(value)
+        return seconds if seconds >= 0 else None
+    except ValueError:
+        pass
+    try:
+        retry_at = parsedate_to_datetime(value)
+        seconds = int((retry_at - datetime.now(timezone.utc)).total_seconds())
+        return seconds if seconds >= 0 else None
+    except (TypeError, ValueError):
+        return None
 
 
 def linkify(url, params):
@@ -1882,15 +1900,20 @@ class AsyncERClient(object):
             httpx.codes.CONFLICT: ERClientRateLimitExceeded
         }
 
+        retry_after = parse_retry_after_header(
+            e.response.headers.get("Retry-After"))
+
         if e.response.status_code in exception_map:
             raise exception_map[e.response.status_code](
                 message=error_details,
                 status_code=e.response.status_code,
-                response_body=e.response.text
+                response_body=e.response.text,
+                retry_after=retry_after
             )
 
         raise ERClientException(
             message=error_details,
             status_code=e.response.status_code,
-            response_body=e.response.text
+            response_body=e.response.text,
+            retry_after=retry_after
         )

--- a/erclient/er_errors.py
+++ b/erclient/er_errors.py
@@ -1,9 +1,12 @@
 class ERClientException(Exception):
     # Optional support for storing status code and response body
-    def __init__(self, message=None, status_code=None, response_body=None):
+    def __init__(self, message=None, status_code=None, response_body=None, retry_after=None):
         super().__init__(message)
         self.status_code = status_code
         self.response_body = response_body
+        # Seconds the server asked us to wait (parsed from the Retry-After
+        # header); None when the header was absent or unparseable.
+        self.retry_after = retry_after
 
     def __str__(self):
         base_message = super().__str__()

--- a/erclient/er_errors.py
+++ b/erclient/er_errors.py
@@ -1,5 +1,6 @@
 class ERClientException(Exception):
-    # Optional support for storing status code and response body
+    # Optional support for storing the status code, response body, and the
+    # parsed Retry-After value from the server response
     def __init__(self, message=None, status_code=None, response_body=None, retry_after=None):
         super().__init__(message)
         self.status_code = status_code

--- a/tests/async_client/test_retry_after.py
+++ b/tests/async_client/test_retry_after.py
@@ -63,3 +63,34 @@ async def test_retry_after_absent_or_unparseable_is_none(er_client, report, head
         assert route.called
         assert exc_info.value.retry_after is None
         await er_client.close()
+
+
+def test_retry_after_http_date_rounds_up_fractional_seconds():
+    # A fractional delta must round up (never retry earlier than requested).
+    # HTTP-dates have whole-second resolution, so the fraction comes from
+    # "now" being mid-second — pin the clock to make this deterministic.
+    from unittest import mock
+
+    from erclient.client import parse_retry_after_header
+
+    fixed_now = datetime(2026, 7, 6, 12, 0, 0, 500000, tzinfo=timezone.utc)
+    retry_at = datetime(2026, 7, 6, 12, 2, 0,
+                        tzinfo=timezone.utc)  # 119.5s later
+    with mock.patch("erclient.client.datetime") as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        assert parse_retry_after_header(
+            format_datetime(retry_at, usegmt=True)) == 120
+
+
+def test_retry_after_http_date_in_past_is_none():
+    from unittest import mock
+
+    from erclient.client import parse_retry_after_header
+
+    fixed_now = datetime(2026, 7, 6, 12, 0, 0, 500000, tzinfo=timezone.utc)
+    retry_at = datetime(2026, 7, 6, 11, 59, 59,
+                        tzinfo=timezone.utc)  # in the past
+    with mock.patch("erclient.client.datetime") as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        assert parse_retry_after_header(
+            format_datetime(retry_at, usegmt=True)) is None

--- a/tests/async_client/test_retry_after.py
+++ b/tests/async_client/test_retry_after.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
+import httpx
+import pytest
+import respx
+
+from erclient import ERClientRateLimitExceeded, ERClientServiceUnreachable
+
+
+@pytest.mark.asyncio
+async def test_retry_after_seconds_on_429(er_client, report):
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post('activity/events')
+        route.return_value = httpx.Response(
+            httpx.codes.TOO_MANY_REQUESTS, headers={"Retry-After": "60"}, json={})
+
+        with pytest.raises(ERClientRateLimitExceeded) as exc_info:
+            await er_client.post_report(report)
+
+        assert route.called
+        assert exc_info.value.retry_after == 60
+        await er_client.close()
+
+
+@pytest.mark.asyncio
+async def test_retry_after_http_date_on_503(er_client, report):
+    retry_at = datetime.now(timezone.utc) + timedelta(seconds=120)
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post('activity/events')
+        route.return_value = httpx.Response(
+            httpx.codes.SERVICE_UNAVAILABLE,
+            headers={"Retry-After": format_datetime(retry_at, usegmt=True)},
+            json={}
+        )
+
+        with pytest.raises(ERClientServiceUnreachable) as exc_info:
+            await er_client.post_report(report)
+
+        assert route.called
+        assert exc_info.value.retry_after is not None
+        assert 100 <= exc_info.value.retry_after <= 120
+        await er_client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("headers", [{}, {"Retry-After": "soonish"}, {"Retry-After": "-5"}])
+async def test_retry_after_absent_or_unparseable_is_none(er_client, report, headers):
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post('activity/events')
+        route.return_value = httpx.Response(
+            httpx.codes.TOO_MANY_REQUESTS, headers=headers, json={})
+
+        with pytest.raises(ERClientRateLimitExceeded) as exc_info:
+            await er_client.post_report(report)
+
+        assert route.called
+        assert exc_info.value.retry_after is None
+        await er_client.close()


### PR DESCRIPTION
## Summary

Parses the `Retry-After` response header (both delta-seconds and HTTP-date forms) in `AsyncERClient._handle_http_status_error` and attaches it as `retry_after: Optional[int]` on `ERClientException` (None when absent, malformed, or negative). Purely additive: the constructor kwarg defaults to None, all existing raise sites are unchanged, and the sync client is untouched.

Motivation: the Gundi ER dispatcher (PADAS/gundi-dispatcher-er#39) now applies per-destination cooldowns when EarthRanger signals distress (429/5xx). It reads `getattr(e, "retry_after", None)` defensively, so it works with current releases — but once this ships, dispatcher backoff will honor the destination's own guidance instead of an exponential default.

**Release requested**: a tagged release including this change lets the dispatcher bump its pin and pick the feature up.

## Testing

5 new tests in `tests/async_client/test_retry_after.py` (respx, modeled on the existing 429 test): delta-seconds on 429 → 60; HTTP-date on 503 → ~120s; absent/malformed/negative → None. Whole async suite: 144 passed; full repo: 190 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112VwWNyti6VJbbKH7CrSDn