### PR TITLE
Publish releases to PyPI via trusted publishing

### DIFF
--- a/.github/scripts/check_version_matches_tag.py
+++ b/.github/scripts/check_version_matches_tag.py
@@ -1,0 +1,42 @@
+"""Release guard: fail unless the release tag matches erclient/version.py.
+
+Usage: python .github/scripts/check_version_matches_tag.py <tag>
+The tag may carry a leading "v" (v1.16.0 == 1.16.0).
+"""
+import ast
+import pathlib
+import sys
+
+VERSION_FILE = pathlib.Path("erclient/version.py")
+
+
+def read_package_version():
+    for node in ast.walk(ast.parse(VERSION_FILE.read_text())):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    getattr(target, "id", None) == "__version__"
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                ):
+                    return node.value.value
+    return None
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(f"Usage: {sys.argv[0]} <release-tag>")
+    tag = sys.argv[1]
+    version = read_package_version()
+    if not version:
+        sys.exit(f"Could not determine __version__ from {VERSION_FILE}")
+    if tag.removeprefix("v") != version:
+        sys.exit(
+            f"Release tag {tag} does not match {VERSION_FILE} ({version}).\n"
+            f"Bump {VERSION_FILE} before tagging the release."
+        )
+    print(f"Tag {tag} matches package version {version}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/check_version_matches_tag.py
+++ b/.github/scripts/check_version_matches_tag.py
@@ -11,7 +11,16 @@ VERSION_FILE = pathlib.Path("erclient/version.py")
 
 
 def read_package_version():
-    for node in ast.walk(ast.parse(VERSION_FILE.read_text())):
+    # A release guard must fail with an actionable one-liner, not a traceback
+    try:
+        source = VERSION_FILE.read_text()
+    except (OSError, UnicodeDecodeError) as e:
+        sys.exit(f"Could not read {VERSION_FILE}: {e}")
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError) as e:
+        sys.exit(f"Could not parse {VERSION_FILE}: {e}")
+    for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if (

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,21 @@ jobs:
       - name: Verify the tag matches the package version
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          PKG_VERSION="$(python -c 'import re, pathlib; print(re.search(r"__version__\s*=\s*.([^\x27\"]+)", pathlib.Path("erclient/version.py").read_text()).group(1))')"
+          # AST parse instead of a regex so a version.py refactor produces a
+          # clear failure here rather than a cryptic parse error.
+          PKG_VERSION="$(python -c '
+          import ast, pathlib, sys
+
+          version = None
+          for node in ast.walk(ast.parse(pathlib.Path("erclient/version.py").read_text())):
+              if isinstance(node, ast.Assign):
+                  for target in node.targets:
+                      if getattr(target, "id", None) == "__version__" and isinstance(node.value, ast.Constant):
+                          version = node.value.value
+          if not isinstance(version, str) or not version:
+              sys.exit("Could not determine __version__ from erclient/version.py")
+          print(version)
+          ')"
           if [ "${TAG#v}" != "${PKG_VERSION}" ]; then
             echo "Release tag ${TAG} does not match erclient/version.py (${PKG_VERSION})." >&2
             echo "Bump erclient/version.py before tagging the release." >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,7 @@ jobs:
       url: https://pypi.org/p/earthranger-client
     permissions:
       id-token: write  # required for PyPI trusted publishing (OIDC)
+      actions: read  # defensive: artifact download (same-run uses the runtime token today)
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -80,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # upload assets to the release
+      actions: read  # defensive: artifact download (same-run uses the runtime token today)
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,28 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Verify the tag matches the package version
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          # AST parse instead of a regex so a version.py refactor produces a
-          # clear failure here rather than a cryptic parse error.
-          PKG_VERSION="$(python -c '
-          import ast, pathlib, sys
-
-          version = None
-          for node in ast.walk(ast.parse(pathlib.Path("erclient/version.py").read_text())):
-              if isinstance(node, ast.Assign):
-                  for target in node.targets:
-                      if getattr(target, "id", None) == "__version__" and isinstance(node.value, ast.Constant):
-                          version = node.value.value
-          if not isinstance(version, str) or not version:
-              sys.exit("Could not determine __version__ from erclient/version.py")
-          print(version)
-          ')"
-          if [ "${TAG#v}" != "${PKG_VERSION}" ]; then
-            echo "Release tag ${TAG} does not match erclient/version.py (${PKG_VERSION})." >&2
-            echo "Bump erclient/version.py before tagging the release." >&2
-            exit 1
-          fi
+        run: python .github/scripts/check_version_matches_tag.py "${{ github.event.release.tag_name }}"
 
       - name: Build sdist and wheel
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,10 @@ on:
   release:
     types: [published]
 
+# Minimal default token scopes; jobs that need more override at job level
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,78 @@
+name: Publish
+
+# Builds once per published GitHub release, then:
+#   - publishes to PyPI via trusted publishing (OIDC — no API tokens), and
+#   - attaches the sdist + wheel to the GitHub release (downstream Gundi
+#     repos pin wheels from release assets).
+#
+# PyPI side (one-time, project owner): pypi.org -> earthranger-client ->
+# Manage -> Publishing -> Add a new publisher (GitHub):
+#   owner: PADAS, repository: er-client,
+#   workflow: publish.yml, environment: pypi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify the tag matches the package version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          PKG_VERSION="$(python -c 'import re, pathlib; print(re.search(r"__version__\s*=\s*.([^\x27\"]+)", pathlib.Path("erclient/version.py").read_text()).group(1))')"
+          if [ "${TAG#v}" != "${PKG_VERSION}" ]; then
+            echo "Release tag ${TAG} does not match erclient/version.py (${PKG_VERSION})." >&2
+            echo "Bump erclient/version.py before tagging the release." >&2
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-to-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/earthranger-client
+    permissions:
+      id-token: write  # required for PyPI trusted publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  attach-to-release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # upload assets to the release
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Attach sdist and wheel to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

`earthranger-client` is on PyPI (currently 1.15.0), but this repo has no publish workflow — releases are built and uploaded manually with credentials, and release-asset wheels are attached by hand. This adds a single `publish.yml` workflow triggered on **release published** that:

1. **Builds once** (`python -m build`, hatchling backend), with a guard that fails fast if the release tag doesn't match `erclient/version.py` (e.g. tagging `v1.16.0` while version.py still says 1.15.0).
2. **Publishes to PyPI via [trusted publishing](https://docs.pypi.org/trusted-publishers/)** (`pypa/gh-action-pypi-publish` with OIDC, `id-token: write`) — no long-lived API tokens to store, rotate, or leak.
3. **Attaches the sdist + wheel to the GitHub release** — the Gundi repos (e.g. gundi-dispatcher-er) pin wheels from release-asset URLs, so this keeps that consumption path working with identical artifact names (verified against a local build: `earthranger_client-<ver>-py3-none-any.whl`).

## One-time setup required after merging (PyPI project owner)

1. On PyPI: `earthranger-client` → Manage → **Publishing** → *Add a new publisher* (GitHub):
   - Owner: `PADAS`, Repository: `er-client`, Workflow: `publish.yml`, Environment: `pypi`
2. On GitHub: repo Settings → Environments → create `pypi` (optionally add required reviewers as a release gate).
3. Once a release publishes successfully through this workflow, revoke any manual PyPI API tokens previously used for uploads.

## Testing

Workflow YAML validated; the tag-vs-version guard and `python -m build` were run locally against the current tree (extracts `1.15.0`, builds both artifacts). The publish path itself can only be exercised by the first real release — recommend trying it on the next release (which #53's `retry_after` feature is waiting for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112VwWNyti6VJbbKH7CrSDn