### PR TITLE
Bump GitHub Actions to current majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '07:00'
+      timezone: 'America/Los_Angeles'
+
+updates:
+  - package-ecosystem: 'github-actions'
+    # '/' is what picks up .github/workflows -- there is no separate glob for it.
+    directory: '/'
+    multi-ecosystem-group: 'all-dependencies'
+    patterns: ['*']

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -36,7 +36,7 @@ jobs:
           python -m pip install --upgrade build
           python -m build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -51,7 +51,7 @@ jobs:
       id-token: write  # required for PyPI trusted publishing (OIDC)
       actions: read  # defensive: artifact download (same-run uses the runtime token today)
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -66,7 +66,7 @@ jobs:
       contents: write  # upload assets to the release
       actions: read  # defensive: artifact download (same-run uses the runtime token today)
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # enable-cache: false everywhere. setup-uv caches by default from v5 on,
+      # but its default key omits the matrix Python (it interpolates the
+      # runner's system Python), so all eleven jobs share one key: they race to
+      # save it, and the winner's wheels get restored into jobs targeting a
+      # different interpreter. Nothing is lost by skipping it — a cold
+      # `uv sync` here resolves in well under a second.
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
+          enable-cache: false
 
       - name: Check lockfile
         run: uv lock --check
@@ -42,6 +49,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
+          enable-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -67,6 +75,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
+          enable-cache: false
 
       - name: Build distributions
         run: uv build
@@ -116,6 +125,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
+          enable-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -197,6 +207,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
+          enable-cache: false
 
       - name: Install from sdist
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     name: uv.lock matches pyproject.toml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
 
@@ -36,10 +36,10 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
 
@@ -61,10 +61,10 @@ jobs:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
 
@@ -74,7 +74,7 @@ jobs:
       - name: Validate metadata
         run: uvx twine check --strict dist/*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -105,15 +105,15 @@ jobs:
       # below) and tests/; the package itself comes from the built wheel,
       # and the source package dir is deleted right after the wheel install
       # so imports can only resolve to the installed wheel.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
 
@@ -188,13 +188,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "latest"
 


### PR DESCRIPTION
Brings every `uses:` tag in `.github/workflows/` up to the current major, fixes the CI warnings that surfaced as a result, and adds a Dependabot config so this doesn't need doing by hand again.

## 1. Action version bumps

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v7` |
| `actions/setup-python` | `v5` | `v7` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |
| `astral-sh/setup-uv` | `v4` | `v10.0.1` |

`setup-uv` is pinned to an exact patch because Astral stopped publishing floating major tags after `v7` — `v8`, `v9`, and `v10` exist only as exact patch tags. `pypa/gh-action-pypi-publish@release/v1` was already on its recommended floating branch ref and is unchanged.

Each tag was verified to resolve upstream and to be the current latest major. Reviewed the release notes for every intervening major; nothing in them bites here:

- Most of the jumps are Node 20 → 24 runtime bumps requiring runner >= 2.327.1. All jobs run on `ubuntu-latest`, which already satisfies that.
- `upload-artifact@v7` direct (unzipped) uploads are opt-in via `archive: false`, so the v7 upload → v8 download pairing in `publish.yml` and `tests.yml` still uses the normal zip path.
- `download-artifact@v8` now **errors** on a digest mismatch instead of warning. Default-safe, and preferable on the publish path — a corrupted transfer fails the run rather than quietly proceeding to PyPI.
- `setup-python@v7` removed the `pip-install` input; `publish.yml` only passes `python-version`.
- `checkout@v7` blocks fork-PR checkout under `pull_request_target` / `workflow_run`. Triggers here are `pull_request` and `release`, so no impact.

## 2. `enable-cache: false` on setup-uv

The bump produced four new CI annotations. `setup-uv` caches by default from v5 on, and its default cache key interpolates the runner's system Python rather than the matrix Python — so all eleven jobs computed one identical key. Three jobs lost the race to save it (`Unable to reserve cache`), and the winner's wheels would be restored into jobs targeting a different interpreter. Separately, `sdist-install-check` has no checkout step, so nothing matched the dependency glob and its key degraded to `-no-dependency-glob`, which as setup-uv warns can never be invalidated.

Disabling restores the pre-bump behavior. Nothing is lost: a cold `uv sync` in these jobs resolves in under a second, so the cache was not buying anything to begin with.

## 3. Dependabot config

New `.github/dependabot.yml` covering `github-actions`, so these bumps arrive as PRs from here on. A multi-ecosystem group collapses updates into a single weekly PR rather than one per ecosystem.

Deliberately scoped to Actions only for now. Adding the `uv` ecosystem later needs a considered `versioning-strategy`: the `>=` floors in `[project.dependencies]` are the contract published to consumers, and `install-check` resolves `--resolution lowest-direct` against them, so a strategy that raises those floors would narrow what consumers can install and hollow out that job.

## Verification

CI is green with **zero annotations** (previously four). The run exercises `checkout@v7`, `setup-uv@v10.0.1`, `upload-artifact@v7`, and `download-artifact@v8` across the full support matrix, so the artifact v7 → v8 pairing is proven.

`publish.yml` only fires on a published release, so `setup-python@v7` and the publish-side artifact download go unexercised until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)