### PR TITLE
Harmonize the pre-commit and uv toolchain, and put it under CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: '/'
     multi-ecosystem-group: 'all-dependencies'
     patterns: ['*']
+
+  - package-ecosystem: 'pre-commit'
+    directory: '/'
+    multi-ecosystem-group: 'all-dependencies'
+    patterns: ['*']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,33 @@ jobs:
       - name: Check lockfile
         run: uv lock --check
 
+  pre-commit:
+    name: pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: false
+          version-file: uv.toml
+
+      # .pre-commit-config.yaml pins default_language_version to python3.10,
+      # so that exact interpreter has to exist here or every `language: python`
+      # hook fails to build its environment. Keep this in step with the pin.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+
+      # pre-commit comes from the locked dev group rather than a bare install,
+      # so CI runs the same version the lockfile gives everyone else.
+      - name: Install pre-commit
+        run: uv sync --locked --only-group dev
+
+      - name: Run hooks
+        run: uv run --no-sync pre-commit run --all-files --show-diff-on-failure
+
   pytest:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "latest"
           enable-cache: false
+          version-file: uv.toml
 
       - name: Check lockfile
         run: uv lock --check
@@ -48,8 +48,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "latest"
           enable-cache: false
+          version-file: uv.toml
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -74,8 +74,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "latest"
           enable-cache: false
+          version-file: uv.toml
 
       - name: Build distributions
         run: uv build
@@ -124,8 +124,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "latest"
           enable-cache: false
+          version-file: uv.toml
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -198,6 +198,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      # Deliberately not a full checkout: `.venv/bin/python -c` puts the
+      # working directory first on sys.path, so a source `erclient/` here
+      # would shadow the sdist install the smoke test is meant to exercise.
+      # uv.toml alone is fetched, only so setup-uv can read the version pin.
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: uv.toml
+          sparse-checkout-cone-mode: false
+
       - uses: actions/download-artifact@v8
         with:
           name: dist
@@ -206,8 +215,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "latest"
           enable-cache: false
+          version-file: uv.toml
 
       - name: Install from sdist
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,9 @@
 # This pins the hooks' runtime only -- the supported range is pyproject's,
 # and the CI matrix is what proves it.
 #
-# 3.10 is that floor today: isort requires >=3.10, as does autoflake's
-# current release, and 3.9 is already EOL. Raise it when the tooling forces
-# the issue; 3.10 itself reaches EOL 2026-10-31.
+# 3.10 is that floor today: isort and autoflake both require >=3.10, and 3.9
+# is already EOL. Raise it when the tooling forces the issue; 3.10 itself
+# reaches EOL 2026-10-31.
 default_language_version:
   python: python3.10
 
@@ -40,8 +40,8 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://github.com/myint/autoflake
-    rev: v2.3.1
+  - repo: https://github.com/pycqa/autoflake
+    rev: v2.4.0
     hooks:
       - id: autoflake
         args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,9 @@
 # This pins the hooks' runtime only -- the supported range is pyproject's,
 # and the CI matrix is what proves it.
 #
-# 3.10 is that floor today: isort needs >=3.9, autoflake's current release
-# needs >=3.10, and 3.9 is already EOL. Raise it when the tooling forces the
-# issue; 3.10 itself reaches EOL 2026-10-31.
+# 3.10 is that floor today: isort requires >=3.10, as does autoflake's
+# current release, and 3.9 is already EOL. Raise it when the tooling forces
+# the issue; 3.10 itself reaches EOL 2026-10-31.
 default_language_version:
   python: python3.10
 
@@ -36,7 +36,7 @@ repos:
         args: ['--in-place']
 
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 9.0.1
     hooks:
       - id: isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,15 @@
+# Hook environments track the lowest Python we can practically run them on,
+# so their behavior stays close to the floor declared in pyproject.toml
+# instead of following whatever python3 each contributor happens to have.
+# This pins the hooks' runtime only -- the supported range is pyproject's,
+# and the CI matrix is what proves it.
+#
+# 3.10 is that floor today: isort needs >=3.9, autoflake's current release
+# needs >=3.10, and 3.9 is already EOL. Raise it when the tooling forces the
+# issue; 3.10 itself reaches EOL 2026-10-31.
+default_language_version:
+  python: python3.10
+
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.7.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.7.12
+    rev: 0.12.5 # keep in sync with version in uv.toml
     hooks:
       - id: uv-lock
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: uv-lock
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,8 @@ repos:
         args: ['--allow-missing-credentials']
       - id: detect-private-key
 
-  - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: 'v2.0.4'
+  - repo: https://github.com/hhatto/autopep8
+    rev: 'v2.3.2'
     hooks:
       - id: autopep8
         args: ['--in-place']

--- a/tests/async_client/test_service_root_normalization.py
+++ b/tests/async_client/test_service_root_normalization.py
@@ -47,7 +47,8 @@ def test_async_service_root_normalization_strips_api_segment(
 
 def test_async_token_url_derived_from_service_root_when_omitted():
     """When token_url is not passed, it defaults to {service_root}/oauth2/token."""
-    client = AsyncERClient(service_root="https://hello.pamdas.org", provider_key="test")
+    client = AsyncERClient(
+        service_root="https://hello.pamdas.org", provider_key="test")
     assert client.token_url == "https://hello.pamdas.org/oauth2/token"
 
 

--- a/tests/sync_client/test_service_root_normalization.py
+++ b/tests/sync_client/test_service_root_normalization.py
@@ -46,7 +46,8 @@ def test_service_root_normalization_strips_api_segment(
 
 def test_token_url_derived_from_service_root_when_omitted():
     """When token_url is not passed, it defaults to {service_root}/oauth2/token."""
-    client = ERClient(service_root="https://hello.pamdas.org", provider_key="test")
+    client = ERClient(service_root="https://hello.pamdas.org",
+                      provider_key="test")
     assert client.token_url == "https://hello.pamdas.org/oauth2/token"
 
 

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,1 @@
+required-version = "==0.12.5" # keep in sync with the uv-pre-commit `rev` in .pre-commit-config.yaml


### PR DESCRIPTION
Harmonizes the local development toolchain so hook behavior is a property of the repo rather than of whoever's machine ran it, and puts the result under CI and Dependabot.

## What changed

**Hook runtime is pinned.** `default_language_version: python3.10` in `.pre-commit-config.yaml`. Hook envs were previously built from whatever `python3` each contributor had. autopep8 was the sharp case: the abandoned `pre-commit/mirrors-autopep8` is frozen at 2.0.4, which imports `lib2to3` — gone from the stdlib in 3.13, so the hook crashed outright on a current interpreter. On 3.12 it ran but reflowed long f-strings by breaking *inside* the replacement field, which is PEP 701 syntax and a `SyntaxError` below 3.12. Since this package supports 3.8+, the formatter was one interpreter choice away from rewriting `erclient/` into code most of the supported range cannot parse.

**Every hook is now on a maintained repo.**

| hook | before | after |
| --- | --- | --- |
| autopep8 | `mirrors-autopep8` v2.0.4 (abandoned) | `hhatto/autopep8` v2.3.2 |
| isort | 6.0.1 | 9.0.1 |
| autoflake | `myint/autoflake` v2.3.1 | `pycqa/autoflake` v2.4.0 |
| pre-commit-hooks | v5.0.0 | v6.0.0 |
| uv-pre-commit | 0.7.12 | 0.12.5 |

**uv is pinned to one version** across CI, pre-commit, and local dev. `uv.toml`'s `required-version` is the single source of truth; `tests.yml` reads it via `version-file: uv.toml` instead of installing `latest`. `sdist-install-check` had no checkout, so it gains a sparse checkout of `uv.toml` alone — deliberately not a full one, since a source `erclient/` there would shadow the sdist install that job's smoke test exists to exercise.

**CI runs the hooks** (`pre-commit run --all-files`) and Dependabot bumps them.

## Notes for review

- **Two test files get reformatted** (`e10a257`). Formatting only — those wraps were owed since the files landed, but autopep8 had been crashing and never reached them.
- **`uv-pre-commit` is intentionally not ignored by Dependabot.** Its rev must move with `required-version` in `uv.toml`, which Dependabot won't edit, so those PRs will fail the new job until `uv.toml` is updated on the branch. The error names both versions and the two files cross-reference each other, so the red build is the prompt.
- **The 3.10 pin has a shelf life.** 3.10 reaches EOL 2026-10-31. It's now an ordinary bump rather than a blocked one: autopep8 2.3.2 produces an identical result on 3.10 and 3.14, so the pin is no longer load-bearing — it stands on keeping `check-ast` compiling near the declared floor. Bumping it means bumping `python-version` in the new CI job too.
- **isort 9.0.1 is a git tag PyPI has not published.** pre-commit installs from a clone of the tag, so it resolves; `pip install isort==9.0.1` will not until upstream uploads.

## Verification

- All twelve hooks pass `pre-commit run --all-files`, which failed on `main` (autopep8 crashed on any interpreter newer than 3.12).
- The CI job's exact command chain was run end-to-end in a clean clone: exit 0.
- `uv lock --check` passes under the pinned uv; the 20 tests in the two reformatted files pass unchanged.
- The uv desync this guards against was reproduced deliberately: `autoupdate` to `uv-pre-commit` 0.12.6 against `required-version = "==0.12.5"` fails the `uv-lock` hook, which is what the new CI job now catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
