### PR TITLE
Ship only the package and its suite in the sdist

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -221,7 +221,7 @@ jobs:
         run: .venv/bin/python -m pytest tests -q
 
   sdist-install-check:
-    name: sdist builds and installs
+    name: sdist ships the right files, installs, and tests
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -238,6 +238,27 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      # tool.hatch.build.targets.sdist in pyproject.toml keeps repo
+      # scaffolding out of the tarball. Assert the result rather than trusting
+      # the config: anything new at the top level is either a deliberate
+      # addition to that include list — in which case add it here too — or
+      # something that leaked back in. pyproject.toml, .gitignore, PKG-INFO,
+      # the readme and license-files are force-included by hatchling and
+      # cannot be dropped, so they are expected members.
+      - name: Check the sdist ships nothing unexpected
+        run: |
+          expected=$(printf '%s\n' \
+            .gitignore LICENSE PKG-INFO README.md pyproject.toml erclient tests \
+            | sort)
+          # Strip the version prefix directory, keep first path segments only.
+          actual=$(tar -tzf dist/*.tar.gz | sed 's|^[^/]*/||' | cut -d/ -f1 | grep . | sort -u)
+          unexpected=$(comm -13 <(echo "$expected") <(echo "$actual"))
+          if [ -n "$unexpected" ]; then
+            echo "::error::unexpected top-level entries in the sdist:"
+            echo "$unexpected"
+            exit 1
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
@@ -257,3 +278,32 @@ jobs:
           from erclient.version import __version__
           print(f'earthranger-client {__version__} imports cleanly')
           "
+
+      # The include list is an allowlist, so its failure mode is shipping too
+      # little. install-check already runs the suite against the built
+      # distribution, but from the *checkout's* tests/ — so a tests/ missing
+      # from the sdist would pass there unnoticed. Unpack what we published
+      # and run the suite out of it, the way a distro repackager would.
+      #
+      # Note this deliberately exercises the sdist's own erclient/: cwd leads
+      # sys.path, so imports resolve to the unpacked source, not the install
+      # above. That is the property under test — the tarball standing alone as
+      # a complete source release.
+      - name: Unpack the sdist
+        run: |
+          mkdir -p "$RUNNER_TEMP/sdist"
+          tar -xzf dist/*.tar.gz -C "$RUNNER_TEMP/sdist" --strip-components=1
+
+      # Taken from the sdist's own [test] extra rather than a hand-written
+      # tool list, so a broken extra declaration fails here too. Unlike
+      # install-check this wants a plain resolution — proving the declared
+      # dependency floors hold is that job's business, not this one's.
+      - name: Install test tooling from the sdist's [test] extra
+        run: |
+          sdist=$(ls dist/*.tar.gz)  # build publishes exactly one
+          uv pip install "${sdist}[test]"
+
+      - name: Run the suite from the unpacked sdist
+        working-directory: ${{ runner.temp }}/sdist
+        run: |
+          "$GITHUB_WORKSPACE/.venv/bin/python" -m pytest tests -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,22 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["erclient"]
 
+# Without this, hatchling's sdist default is "every file git doesn't ignore",
+# which sweeps in repo scaffolding nobody installing the package needs
+# (.github/, .vscode/, .pre-commit-config.yaml, .isort.cfg, uv.lock, uv.toml,
+# *.nix) plus any untracked file sitting in the working tree at build time.
+#
+# The list below is everything we ship beyond the metadata: pyproject.toml,
+# .gitignore, PKG-INFO, the readme, and license-files are force-included by
+# hatchling whatever it says, so they don't need naming. tests/ is here so the
+# suite is runnable from a published sdist — see the respx floor note under
+# [project.optional-dependencies].
+[tool.hatch.build.targets.sdist]
+include = [
+    "erclient/",
+    "tests/",
+]
+
 [project]
 name = "earthranger-client"
 dynamic = ["version"]


### PR DESCRIPTION
## Problem

`pyproject.toml` configured a `wheel` build target but no `sdist` one, so hatchling
fell back to its default: include every file git doesn't ignore. That is most of the
repo. The sdist we published for 1.16.0 — still on PyPI — carries:

```
.github/CODEOWNERS          .isort.cfg
.github/scripts/            .pre-commit-config.yaml
.github/workflows/          .vscode/settings.json
development.md              uv.lock
docs/examples/
```

None of it tells a consumer anything. `uv.lock` is actively misleading: it pins the
*dev* environment, not the package's runtime dependencies, and at 364 KB uncompressed
it was roughly three quarters of the raw payload.

The same default has a second edge. "Not gitignored" includes files git isn't tracking
at all, so an sdist built anywhere other than a clean CI checkout picks up whatever
happens to be sitting in the working tree.

## Change

**`pyproject.toml`** — declare an explicit allowlist for the sdist target:

```toml
[tool.hatch.build.targets.sdist]
include = [
    "erclient/",
    "tests/",
]
```

Two notes on why that list is so short. It's an allowlist rather than an `exclude`
denylist because the allowlist fails closed — add a new linter tomorrow and its dotfile
stays out without anyone remembering to exclude it. And `pyproject.toml`, `.gitignore`,
`PKG-INFO`, the readme and `license-files` are force-included by hatchling
(`builders/sdist.py`, `get_default_build_data`) regardless of what this list says, so
naming them would be redundant.

`tests/` stays in deliberately: the suite should be runnable from a published sdist.

The wheel is untouched — same file list before and after.

**`.github/workflows/tests.yml`** — `sdist-install-check` installed the tarball and
imported from it, which says nothing about which files it contains. Both directions of
drift were unguarded, so this adds one check for each.

*Shipping too much.* Assert the sdist's top-level members against an expected set.
Anything new is either a deliberate addition to the include list or something that
leaked back in.

*Shipping too little.* An allowlist's failure mode is omitting real source. The existing
`install-check` job does run the suite against the built distribution, but it takes
`tests/` from the checkout — so a `tests/` missing from the sdist would pass there
unnoticed. This unpacks what we published and runs the suite out of it, the way a distro
repackager would. Note it deliberately exercises the sdist's own `erclient/`: cwd leads
`sys.path`, so imports resolve to the unpacked source rather than the install. The
property under test is the tarball standing alone as a complete source release.

Test tooling for that step comes from the sdist's own `[test]` extra rather than a
hand-written tool list, so a broken extra declaration fails here too. Unlike
`install-check` it takes a plain resolution — proving the declared dependency floors
hold is that job's business, not this one's.

## Evidence

| Check | Result |
|---|---|
| Guard vs. this branch's sdist | passes |
| Guard vs. the published 1.16.0 sdist | flags all seven top-level entries listed above |
| Suite from an unpacked tarball, clean venv | 192 passed |
| Wheel file list | unchanged |
| sdist size, compressed | 329 KB → 202 KB |
| `uv lock --check`, `twine check --strict` | pass |

## For reviewers

The expected-members list in `tests.yml` is now a second place to update: adding to
`include` means adding there too. That's the deliberate cost of asserting the outcome
instead of trusting the config, and the failure message names the offending paths so the
fix is self-evident.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
