### PR TITLE
Run the same CI on the v2 integration branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,14 @@
 name: Tests
 
+# `v2` is the long-lived integration branch for the 2.0 migration — a shadow
+# main that gets the same CI until the big-bang merge. Both branches list both
+# names so this trigger block stays identical on each and never has to be
+# merged; drop `v2` at the flip.
 on:
   push:
-    branches: [main]
+    branches: [main, v2]
   pull_request:
-    branches: [main]
+    branches: [main, v2]
 
 permissions:
   contents: read
@@ -22,7 +26,7 @@ jobs:
 
       # enable-cache: false everywhere. setup-uv caches by default from v5 on,
       # but its default key omits the matrix Python (it interpolates the
-      # runner's system Python), so all eleven jobs share one key: they race to
+      # runner's system Python), so every job shares one key: they race to
       # save it, and the winner's wheels get restored into jobs targeting a
       # different interpreter. Nothing is lost by skipping it — a cold
       # `uv sync` here resolves in well under a second.
@@ -47,12 +51,25 @@ jobs:
           enable-cache: false
           version-file: uv.toml
 
-      # .pre-commit-config.yaml pins default_language_version to python3.10,
-      # so that exact interpreter has to exist here or every `language: python`
-      # hook fails to build its environment. Keep this in step with the pin.
+      # .pre-commit-config.yaml pins default_language_version, and that exact
+      # interpreter has to exist here or every `language: python` hook fails to
+      # build its environment. Read the pin rather than restating it: the two
+      # drifting apart is a confusing failure, and main and v2 pin different
+      # interpreters, so neither copy of this file should have to know which.
+      - name: Read the pre-commit interpreter pin
+        id: precommit-python
+        run: |
+          version=$(sed -n 's/^[[:space:]]*python:[[:space:]]*python\([0-9][0-9.]*\)[[:space:]]*$/\1/p' .pre-commit-config.yaml)
+          if [ -z "$version" ]; then
+            echo "::error::could not read default_language_version.python from .pre-commit-config.yaml"
+            exit 1
+          fi
+          echo "Hooks run on Python $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.10'
+          python-version: ${{ steps.precommit-python.outputs.version }}
 
       # pre-commit comes from the locked dev group rather than a bare install,
       # so CI runs the same version the lockfile gives everyone else.
@@ -66,6 +83,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Keep in step with the Programming Language :: Python classifiers and
+      # requires-python in pyproject.toml -- this list is what proves them.
+      #
+      # v2 narrows it to 3.11+ along with the floor, so this is the one line in
+      # this file that legitimately differs between the branches, and a sync
+      # merge conflicts here only if main also changes it (adding 3.15, say).
+      # Resolve toward v2's floor, keeping any version main added at the top;
+      # never take main's lower bound onto v2. Getting that wrong is loud, not
+      # silent -- uv refuses to sync a >=3.11 project into an older venv.
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 


### PR DESCRIPTION
## Why now

The 2.0 work — collapsing the sync and async clients onto a single HTTP transport, and adding authorization-server discovery so the client keeps working as sites convert to Auth0 — is too large to land incrementally on `main` without leaving the v1 line unreleasable for months. So it gets built on a long-lived `v2` branch that shadows `main` until a single merge at the end.

That branch needs CI from its first commit, and CI has to be configured *before* the branch is cut. `.github/workflows/tests.yml` is branch-local content: a `v2` cut from today's `main` would carry `branches: [main]`, match neither a push to `v2` nor a PR into it, and run nothing at all. This PR is that prerequisite, and nothing else.

## What changed

**`v2` added to both branch triggers.** Both branches list both names, so this block stays byte-identical on each and a sync merge never has to resolve it. Remove `v2` when the branch is merged and deleted.

**The pre-commit interpreter is read from `.pre-commit-config.yaml`** instead of being restated in the workflow. `v2` raises that pin to 3.11 alongside the package floor while `main` stays on 3.10, and the comment this replaces asked whoever changed one to remember the other. Now neither copy of the file has to know which branch it is on.

**The pytest matrix carries a comment explaining the one intended divergence.** `v2` narrows it to 3.11+ with the floor, so a sync merge conflicts there only if `main` also changes the list — adding 3.15, say. The comment says how to resolve it, and notes that getting it wrong fails loudly: uv refuses to sync a `>=3.11` project into an older venv, so a mis-merged matrix cannot ship quietly.

Also drops a stale job count from the caching comment, since that number moves with the matrix.

## What this enables

With this merged, `v2` can be cut from `main` and immediately gets the suite, the lockfile check, the hooks, and the packaging proofs. Feature work for the transport swap and the auth module targets `v2` from there.

`v2` is kept ahead of `main` by merging locally — `git merge origin/main` on `v2`, then push. That always produces a real merge commit, which is what keeps the eventual merge back into `main` a trivial one rather than a conflict archaeology project.

## Order of operations

Merge this first, then cut `v2` from `main`'s tip. Cutting the branch first means it inherits the old trigger and gets no CI until `main` is merged into it.

## Verification

The new pre-commit step runs on this PR, so that half proves itself here. The `v2` trigger cannot be exercised until the branch exists — the first push to `v2` is its proof, and no checks appearing is the symptom of the ordering above.