### PR TITLE
Include exception type when a request error has no message

### DIFF
--- a/erclient/client.py
+++ b/erclient/client.py
@@ -1593,7 +1593,9 @@ class AsyncERClient(object):
             except httpx.RequestError as e:
                 # Network errors, timeouts
                 # ToDo: Check if we want a more granular error handling defining more specific exception classes
-                reason = str(e)
+                # Many httpx transport errors (ReadTimeout, ConnectTimeout, ...) stringify to
+                # an empty string, which made this error arrive with no detail at all.
+                reason = str(e) or type(e).__name__
                 self.logger.error('Request to ER failed', extra=dict(provider_key=self.provider_key,
                                                                      url=request_url,
                                                                      status_code=None,
@@ -1854,7 +1856,9 @@ class AsyncERClient(object):
             except httpx.RequestError as e:
                 # Network errors, timeouts
                 # ToDo: Check if we want a more granular error handling defining more specific exception classes
-                reason = str(e)
+                # Many httpx transport errors (ReadTimeout, ConnectTimeout, ...) stringify to
+                # an empty string, which made this error arrive with no detail at all.
+                reason = str(e) or type(e).__name__
                 self.logger.error('Request to ER failed', extra=dict(provider_key=self.provider_key,
                                                                      url=request_url,
                                                                      status_code=None,

--- a/tests/async_client/test_post_camera_trap_report.py
+++ b/tests/async_client/test_post_camera_trap_report.py
@@ -166,3 +166,30 @@ async def test_post_camera_trap_report_status_not_found(er_client, camera_trap_p
             await er_client.post_camera_trap_report(camera_trap_payload, camera_trap_file)
         assert route.called  # Check that the api endpoint was called
         await er_client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("side_effect,expected", [
+    # httpx transport errors usually carry no message, which used to produce a
+    # bare "Request to ER failed: " with nothing for the caller to act on.
+    (httpx.ReadTimeout(""), "Request to ER failed: ReadTimeout"),
+    (httpx.ConnectTimeout(""), "Request to ER failed: ConnectTimeout"),
+    (httpx.ConnectError(""), "Request to ER failed: ConnectError"),
+    # A message that is already present must be passed through untouched.
+    (httpx.ConnectError("nodename nor servname provided"),
+     "Request to ER failed: nodename nor servname provided"),
+])
+async def test_post_camera_trap_report_request_error_message(
+    er_client, camera_trap_payload, camera_trap_file, side_effect, expected
+):
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post(
+            f'sensors/camera-trap/{er_client.provider_key}/status/')
+        route.side_effect = side_effect
+        with pytest.raises(ERClientException) as exc_info:
+            await er_client.post_camera_trap_report(camera_trap_payload, camera_trap_file)
+        assert route.called
+        assert str(exc_info.value) == expected
+        await er_client.close()

--- a/tests/async_client/test_post_report.py
+++ b/tests/async_client/test_post_report.py
@@ -174,3 +174,25 @@ async def test_post_report_status_unauthorized(er_client, report, bad_credential
         expected_message = f'ER Unauthorized ON POST {er_client._er_url("activity/events")}. (status_code={httpx.codes.UNAUTHORIZED})'
         assert expected_message in str(exc_info.value)
         assert route.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("side_effect,expected", [
+    # Same fallback as the multipart path, for the shared JSON request helper.
+    (httpx.ReadTimeout(""), "Request to ER failed: ReadTimeout"),
+    (httpx.ConnectTimeout(""), "Request to ER failed: ConnectTimeout"),
+    (httpx.ConnectError(""), "Request to ER failed: ConnectError"),
+    (httpx.ConnectError("nodename nor servname provided"),
+     "Request to ER failed: nodename nor servname provided"),
+])
+async def test_post_report_request_error_message(er_client, report, side_effect, expected):
+    async with respx.mock(
+            base_url=er_client._api_root("v1.0"), assert_all_called=False
+    ) as respx_mock:
+        route = respx_mock.post('activity/events')
+        route.side_effect = side_effect
+        with pytest.raises(ERClientException) as exc_info:
+            await er_client.post_report(report)
+        assert route.called
+        assert str(exc_info.value) == expected
+        await er_client.close()


### PR DESCRIPTION
## What

`httpx` transport errors (`ReadTimeout`, `ConnectTimeout`, `ConnectError`) often stringify to an empty string, so `ERClientException` was raised as `Request to ER failed: ` with no detail at all.

Two lines change `reason = str(e)` to `reason = str(e) or type(e).__name__`, so the message reads `Request to ER failed: ReadTimeout`. Non-empty messages are unchanged.

## Why

7 er2er integrations in production are currently failing with exactly this empty message, which gives us nothing to act on.


🤖 Generated with [Claude Code](https://claude.com/claude-code)